### PR TITLE
Adding DependsOn property to QBusinessPlugin resource

### DIFF
--- a/deployment/Q-App.yaml
+++ b/deployment/Q-App.yaml
@@ -98,6 +98,7 @@ Resources:
                     arn:aws:qbusiness:${AWS::Region}:${AWS::AccountId}:application/${QBusinessApplication}/index/*/data-source/*
   QBusinessPlugin:
     Type: 'AWS::QBusiness::Plugin'
+    DependsOn: QBusinessApplication
     Properties:
       ApplicationId: !Ref QBusinessApplication
       DisplayName: HRTimeOff


### PR DESCRIPTION
**Context:**
When I cloned the repository ([guidance-for-ai-assistants-with-amazon-q-business](https://github.com/aws-solutions-library-samples/guidance-for-ai-assistants-with-amazon-q-business)), I got the following error trying to deploy the `Q-App.yml` template in CloudFormation:

> This AWS:QBusiness::Plugin resource is in a CREATE_FAILED state. Resource handler returned message: "Cannot fulfill the request since provided application with ID: 15bbdOcf-af58-4fea-8275-af99985c8391 is not in ACTIVE state..."

![image](https://github.com/user-attachments/assets/f62c06a1-12c5-4e37-ab2d-df4bc29f621f)

**Description of changes:**
After adding the `DependsOn` property to the `QBusinessPlugin` resource, the stack successfully deploys:
<img width="934" alt="image" src="https://github.com/user-attachments/assets/e9c29c43-9ff7-4a3f-a76c-79892b345a96" />


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
